### PR TITLE
Fix portable text error in footer (turns out it was just the await?)

### DIFF
--- a/components/Block/Caption.vue
+++ b/components/Block/Caption.vue
@@ -5,6 +5,8 @@
 </template>
 
 <script setup>
+import BlockCopyCode from "~/components/Block/CopyCode.vue";
+
 const props = defineProps({
   caption: {
     type: Array,
@@ -13,20 +15,8 @@ const props = defineProps({
 });
 
 const serializers = {
-  types: {
-    // This is how to access a component registered by `@nuxt/components`
-    // lazyRegisteredComponent: resolveComponent('LazyCustomSerializer'),
-    // A directly imported component
-    // importedComponent: CustomBlockComponent,
-    // Example of a more complex async component
-    // dynamicComponent: defineAsyncComponent({
-    //   loadingComponent: () => 'Loading...',
-    //   loader: () => import('~/other/component.vue'),
-    // }),
-  },
   marks: {
-    // You can also just pass a string for a custom serializer if it's an HTML element
-    // internalLink: BlockInternalLink,
+    code: BlockCopyCode,
   },
 };
 </script>

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -102,7 +102,7 @@ const customSerializers = {
   },
 };
 
-const { data, error, status, refresh } = await useSanityQuery(settingsFooter);
+const { data, error, status, refresh } = useSanityQuery(settingsFooter);
 
 const date = new Date().getFullYear();
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -90,7 +90,6 @@ export default defineNuxtConfig({
     },
   },
 
-  // this is causing the netlify error:
-  // error decoding lambda response: error decoding lambda
-  // compatibilityDate: "2024-12-05",
+  // This gets automatically added when running nuxt but seems like the issue is fixed
+  compatibilityDate: "2025-01-26",
 });


### PR DESCRIPTION
This one is wild but after digging even more it turns out it was just the await causing the issue